### PR TITLE
fix: treat microlink.io content hosts as valid target URLs

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -48,17 +48,22 @@ const normalizeInput = (input, endpoint) => {
   // query string) so a bare target URL is left untouched.
   let isApiInput = /^\??url=/.test(input) || input.startsWith('?')
 
-  // Always strip a canonical `*.microlink.io` host (users paste these into any
-  // binary), plus the binary's own endpoint host when it isn't on microlink.io.
-  const sanitizers = [microlinkUrl()]
-  const endpointRegex = endpointUrl(endpoint)
-  if (endpointRegex) sanitizers.push(endpointRegex)
+  // Host stripping only applies to an actual API request, which always carries a
+  // `url=` query. A bare target URL — even on a microlink.io content host such as
+  // cdn.microlink.io — has none, so its host must survive untouched.
+  if (/(?:^|[?&])url=/.test(input)) {
+    // Strip a canonical `*.microlink.io` host (users paste these into any
+    // binary), plus the binary's own endpoint host when it isn't on microlink.io.
+    const sanitizers = [microlinkUrl()]
+    const endpointRegex = endpointUrl(endpoint)
+    if (endpointRegex) sanitizers.push(endpointRegex)
 
-  for (const regex of sanitizers) {
-    const next = normalized.replace(regex, '')
-    if (next !== normalized) {
-      isApiInput = true
-      normalized = next
+    for (const regex of sanitizers) {
+      const next = normalized.replace(regex, '')
+      if (next !== normalized) {
+        isApiInput = true
+        normalized = next
+      }
     }
   }
 

--- a/test/normalize-input.js
+++ b/test/normalize-input.js
@@ -52,6 +52,23 @@ test('bare target URL is left untouched', t => {
   )
 })
 
+test('a microlink.io content host is a valid target, not an API host', t => {
+  // cdn.microlink.io (and other content hosts) carry no `url=` param, so the
+  // host must not be stripped as if it were an API endpoint
+  t.is(
+    normalizeInput('https://cdn.microlink.io/file-examples/sample.docx'),
+    'https://cdn.microlink.io/file-examples/sample.docx'
+  )
+  // even given a dev endpoint, and with appended flags
+  t.is(
+    normalizeInput(
+      'https://cdn.microlink.io/file-examples/sample.docx&pdf=true&meta=false',
+      'http://localhost:3000'
+    ),
+    'https://cdn.microlink.io/file-examples/sample.docx&pdf=true&meta=false'
+  )
+})
+
 test('endpoint host is stripped when passed (microlink-dev / microlink-next)', t => {
   t.is(
     normalizeInput(


### PR DESCRIPTION
## Problem

```
microlink-dev 'https://cdn.microlink.io/file-examples/sample.docx&pdf=true&meta=false'
# FAIL: The `url` as `file-examples/sample.docx` is not valid (EINVALURLCLIENT)
```

The CLI stripped the `cdn.microlink.io` host as if it were an API endpoint, leaving an invalid bare path.

## Cause

`normalizeInput` stripped any `*.microlink.io` host unconditionally, so a plain content URL (cdn, etc.) lost its host.

## Fix

Host stripping now only runs for API-shaped input, which always carries a `url=` query. A bare target URL on a microlink.io content host has none, so it survives untouched. All existing normalization cases (API paste, endpoint stripping, port-prefix safety) are preserved; added tests for the content-host case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, test-backed change to CLI input normalization with no auth or data-path impact; existing API-paste cases remain covered by tests.
> 
> **Overview**
> Fixes the CLI rejecting **bare** `https://cdn.microlink.io/...` targets because `normalizeInput` stripped any `*.microlink.io` host as if the paste were an API URL.
> 
> **Host stripping** (microlink API host + binary `endpoint` host) now runs only when the input is **API-shaped**—it contains a `url=` query (`(?:^|[?&])url=`). Plain target URLs, including microlink content hosts, stay unchanged; pasted `api.microlink.io/?url=…` behavior is unchanged.
> 
> Tests cover `cdn.microlink.io` with and without a dev `endpoint` and trailing `&pdf=true`-style flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3db5add0678971dea0d15575724e5766aaba47d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->